### PR TITLE
Allow using output from css`` inside literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "^3.2.2"
   },
   "peerDependencies": {
+    "@types/styled-components": "^5.0.1",
     "react": ">=15.x.x",
     "react-dom": ">=15.x.x",
     "styled-components": ">=3.x.x"

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { css } from 'styled-components';
 import '@invisionag/jest-styled-components';
 import '@testing-library/jest-dom/extend-expect';
 import { render, screen } from '@testing-library/react';
@@ -32,6 +33,18 @@ const RuntimeStyledComponent: React.FC<
   );
 };
 
+const ComponentWithInterpolation: React.FC = () => {
+  const someStyles = css`
+    background-color: red;
+  `;
+  const { className } = useStyles()`${someStyles}`;
+  return (
+    <div data-testid="target-component" className={className}>
+      classname is {className}
+    </div>
+  );
+};
+
 describe('react-styledown', () => {
   it('attaches static styles to the dom', () => {
     render(<StaticallyStyledComponent />);
@@ -58,5 +71,13 @@ describe('react-styledown', () => {
     const myComponent = screen.getByText(/classname is.*/);
 
     expect(myComponent).toHaveClass('my-component');
+  });
+
+  it('takes interpolation results as expressions', () => {
+    render(<ComponentWithInterpolation />);
+
+    const myComponent = screen.getByText(/classname is.*/);
+
+    expect(myComponent).toHaveStyleRule('background-color: red');
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
-import styled, { CSSObject, InterpolationFunction } from 'styled-components';
+import styled, {
+  CSSObject,
+  InterpolationFunction,
+  Interpolation,
+} from 'styled-components';
 
 export function useStyles<T = {}>(
   props?: React.HTMLAttributes<HTMLDivElement> & T,
 ) {
   return (
     literal: TemplateStringsArray | CSSObject | InterpolationFunction<any>,
-    ...expressions:
-      | TemplateStringsArray
-      | CSSObject[]
-      | InterpolationFunction<any>[]
+    ...expressions: TemplateStringsArray | CSSObject[] | Interpolation<any>[]
   ) => {
     const [className, setClassName] = React.useState<string>();
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,6 @@
     "declaration": true,
     "outDir": "dist"
   },
-  "files": ["./src/index.tsx"]
+  "files": ["./src/index.tsx", "./src/index.test.tsx"],
+  "typeRoots": ["./node_modules/@types"]
 }


### PR DESCRIPTION
No longer throw an error in case of using `useStyles` in combination with `css` like so

```ts
const someStyles = css`background-color: red`;

useStyles()`${someStyles}`
```